### PR TITLE
Improved KMeans

### DIFF
--- a/src/main/java/net/semanticmetadata/lire/classifiers/AtomicDouble.java
+++ b/src/main/java/net/semanticmetadata/lire/classifiers/AtomicDouble.java
@@ -1,0 +1,105 @@
+package net.semanticmetadata.lire.classifiers;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+public class AtomicDouble extends Number {
+    private static final long serialVersionUID = 0L;
+    private transient volatile long value;
+    private static final AtomicLongFieldUpdater<AtomicDouble> updater = AtomicLongFieldUpdater.newUpdater(AtomicDouble.class, "value");
+
+    public AtomicDouble(double initialValue) {
+        this.value = Double.doubleToRawLongBits(initialValue);
+    }
+
+    public AtomicDouble() {
+    }
+
+    public final double get() {
+        return Double.longBitsToDouble(this.value);
+    }
+
+    public final void set(double newValue) {
+        long next = Double.doubleToRawLongBits(newValue);
+        this.value = next;
+    }
+
+    public final void lazySet(double newValue) {
+        this.set(newValue);
+    }
+
+    public final double getAndSet(double newValue) {
+        long next = Double.doubleToRawLongBits(newValue);
+        return Double.longBitsToDouble(updater.getAndSet(this, next));
+    }
+
+    public final boolean compareAndSet(double expect, double update) {
+        return updater.compareAndSet(this, Double.doubleToRawLongBits(expect), Double.doubleToRawLongBits(update));
+    }
+
+    public final boolean weakCompareAndSet(double expect, double update) {
+        return updater.weakCompareAndSet(this, Double.doubleToRawLongBits(expect), Double.doubleToRawLongBits(update));
+    }
+
+    public final double getAndAdd(double delta) {
+        long current;
+        double currentVal;
+        long next;
+        do {
+            current = this.value;
+            currentVal = Double.longBitsToDouble(current);
+            double nextVal = currentVal + delta;
+            next = Double.doubleToRawLongBits(nextVal);
+        } while(!updater.compareAndSet(this, current, next));
+
+        return currentVal;
+    }
+
+    public final double addAndGet(double delta) {
+        long current;
+        double nextVal;
+        long next;
+        do {
+            current = this.value;
+            double currentVal = Double.longBitsToDouble(current);
+            nextVal = currentVal + delta;
+            next = Double.doubleToRawLongBits(nextVal);
+        } while(!updater.compareAndSet(this, current, next));
+
+        return nextVal;
+    }
+
+    public final double divideAndGet(double divisor){
+        long current;
+        double nextVal;
+        long next;
+        do {
+            current = this.value;
+            double currentVal = Double.longBitsToDouble(current);
+            nextVal = currentVal / divisor;
+            next = Double.doubleToRawLongBits(nextVal);
+        } while(!updater.compareAndSet(this, current, next));
+
+        return nextVal;
+    }
+
+    public String toString() {
+        return Double.toString(this.get());
+    }
+
+    public int intValue() {
+        return (int)this.get();
+    }
+
+    public long longValue() {
+        return (long)this.get();
+    }
+
+    public float floatValue() {
+        return (float)this.get();
+    }
+
+    public double doubleValue() {
+        return this.get();
+    }
+
+}

--- a/src/main/java/net/semanticmetadata/lire/classifiers/KMeans.java
+++ b/src/main/java/net/semanticmetadata/lire/classifiers/KMeans.java
@@ -172,7 +172,7 @@ public class KMeans {
                 System.err.println("** There is NO member in cluster " + i);
                 // fill it with a random member?!?
                 int index = (int) Math.floor(Math.random()*features.size());
-                for (int j=0;j<features.get(index).length;j++) clusters[i].assignMember(features.get(index));
+                clusters[i].assignMember(features.get(index));
             }
             cluster.move();
         }

--- a/src/test/java/net/semanticmetadata/lire/classifiers/TestKMeans.java
+++ b/src/test/java/net/semanticmetadata/lire/classifiers/TestKMeans.java
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the LIRE project: http://lire-project.net
+ * LIRE is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * LIRE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with LIRE; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * We kindly ask you to refer the any or one of the following publications in
+ * any publication mentioning or employing Lire:
+ *
+ * Lux Mathias, Savvas A. Chatzichristofis. Lire: Lucene Image Retrieval -
+ * An Extensible Java CBIR Library. In proceedings of the 16th ACM International
+ * Conference on Multimedia, pp. 1085-1088, Vancouver, Canada, 2008
+ * URL: http://doi.acm.org/10.1145/1459359.1459577
+ *
+ * Lux Mathias. Content Based Image Retrieval with LIRE. In proceedings of the
+ * 19th ACM International Conference on Multimedia, pp. 735-738, Scottsdale,
+ * Arizona, USA, 2011
+ * URL: http://dl.acm.org/citation.cfm?id=2072432
+ *
+ * Mathias Lux, Oge Marques. Visual Information Retrieval using Java and LIRE
+ * Morgan & Claypool, 2013
+ * URL: http://www.morganclaypool.com/doi/abs/10.2200/S00468ED1V01Y201301ICR025
+ */
+
+package net.semanticmetadata.lire.classifiers;
+
+import junit.framework.TestCase;
+
+import java.util.Random;
+
+/**
+ * Created by lazaros on 11/12/2015.
+ *
+ * @author Lazaros Tsochatzidis, ltsochat@ee.duth.gr
+ */
+public class TestKMeans extends TestCase {
+    public void testKMeans() throws Exception {
+        //TestCase parameters
+        int dimensionality=128;
+        int Nclusters=50;
+        int Ndata=10000;
+
+        // Populating KMeans
+        KMeans kMeans=new KMeans(Nclusters);
+        Random rand=new Random();
+        double[] point;
+        for (int i=0;i<Ndata;i++) {
+            point=new double[dimensionality];
+            for (int j=0;j<dimensionality;j++){
+                point[j]=rand.nextDouble();
+            }
+            kMeans.addFeature(point);
+        }
+
+        //Clustering
+        kMeans.init();
+        System.out.println("Step.");
+        double threshold = Math.max(20.0D, (double) kMeans.getFeatureCount() / 1000.0D);
+        double err1 = kMeans.clusteringStep();
+        while(err1 > threshold) {
+            System.out.println(" -> Next step. Stress difference ~ " + (int) err1);
+            err1 = kMeans.clusteringStep();
+        }
+    }
+
+    public void testParallelKMeans() throws Exception {
+        //TestCase parameters
+        int dimensionality=128;
+        int Nclusters=50;
+        int Ndata=10000;
+
+        // Populating KMeans
+        KMeans kMeans=new ParallelKMeans(Nclusters);
+        Random rand=new Random();
+        double[] point;
+        for (int i=0;i<Ndata;i++) {
+            point=new double[dimensionality];
+            for (int j=0;j<dimensionality;j++){
+                point[j]=rand.nextDouble();
+            }
+            kMeans.addFeature(point);
+        }
+
+        //Clustering
+        kMeans.init();
+        System.out.println("Step.");
+        double threshold = Math.max(20.0D, (double) kMeans.getFeatureCount() / 1000.0D);
+        double err1 = kMeans.clusteringStep();
+        while(err1 > threshold) {
+            System.out.println(" -> Next step. Stress difference ~ " + (int) err1);
+            err1 = kMeans.clusteringStep();
+        }
+    }
+}


### PR DESCRIPTION
Existing KMeans keeps history of assignments of features to clusters. And after the assignment it re-computes the distances to get stress. This adds overhead to both memory and CPU.

The new version of KMeans calculates new means on the fly (thread safe). The stress calculation is different and is based on the distance between new and old means. So it represents the stress difference rather than the actual stress.