### PR TITLE
Address issue #39

### DIFF
--- a/src/main/java/net/semanticmetadata/lire/indexers/parallel/ParallelIndexer.java
+++ b/src/main/java/net/semanticmetadata/lire/indexers/parallel/ParallelIndexer.java
@@ -1067,6 +1067,8 @@ public class ParallelIndexer implements Runnable {
                     }
                 } catch (InterruptedException | IOException e) {
                     log.severe(e.getMessage());
+                }  catch (Exception e) {
+                    log.severe(e.getMessage());
                 }
             }
         }
@@ -1110,6 +1112,8 @@ public class ParallelIndexer implements Runnable {
                     }
                 } catch (InterruptedException e) {
                     log.severe(e.getMessage());
+                }  catch (Exception e) {
+                    log.severe(e.getMessage());
                 }
             }
         }
@@ -1148,6 +1152,8 @@ public class ParallelIndexer implements Runnable {
                         }
                     }
                 } catch (InterruptedException | IOException e) {
+                    log.severe(e.getMessage());
+                } catch (Exception e) {
                     log.severe(e.getMessage());
                 }
             }


### PR DESCRIPTION
Address issue #39 and don't crash ParallelIndexer threads when a single item fails (which is common when one of a few thousand images has issues or a file with the wrong type finds its way in).