### PR TITLE
Single locale change for correct boostedQuery generating

### DIFF
--- a/src/main/java/net/semanticmetadata/lire/indexers/hashing/MetricSpaces.java
+++ b/src/main/java/net/semanticmetadata/lire/indexers/hashing/MetricSpaces.java
@@ -346,11 +346,14 @@ public class MetricSpaces {
         StringBuilder sb = new StringBuilder(results.size() * 12);
         double max = results.size();
         double pos = results.size();
+        Locale currentLocale = Locale.getDefault();
+        Locale.setDefault(Locale.ENGLISH);
         for (Iterator<Result> resultIterator = results.iterator(); resultIterator.hasNext(); ) {
             Result result = resultIterator.next();
             sb.append(String.format("R%06d^%1.2f ", result.index, pos / max));
             pos--;
         }
+        Locale.setDefault(currentLocale);
         return sb.toString();
     }
 


### PR DESCRIPTION
Different locales have different decimal and thousands separators. For example, French locale has radix character as a "comma". The Java Virtual Machine sets the default locale during startup based on the host environment. It's possible to face invalid generated query - because Solr only accepts a dot as a decimal separator.