### PR TITLE
Migrate to Lucene 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,9 +19,9 @@ repositories {
 }
 
 dependencies {
-    compile group: 'org.apache.lucene', name: 'lucene-core', version: '7.5.0'
-    compile group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: '7.5.0'
-    compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: '7.5.0'
+    compile group: 'org.apache.lucene', name: 'lucene-core', version: '8.0.0'
+    compile group: 'org.apache.lucene', name: 'lucene-analyzers-common', version: '8.0.0'
+    compile group: 'org.apache.lucene', name: 'lucene-queryparser', version: '8.0.0'
     compile group: 'commons-io', name: 'commons-io', version: '2.6'
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     // https://mvnrepository.com/artifact/commons-codec/commons-codec

--- a/src/main/java/net/semanticmetadata/lire/indexers/LireCustomCodec.java
+++ b/src/main/java/net/semanticmetadata/lire/indexers/LireCustomCodec.java
@@ -43,7 +43,7 @@ package net.semanticmetadata.lire.indexers;
 
 import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.StoredFieldsFormat;
-import org.apache.lucene.codecs.lucene70.Lucene70Codec;
+import org.apache.lucene.codecs.lucene80.Lucene80Codec;
 
 /**
  * Custom stored fields compression configuration. Smaller chunk size and faster compression routine.
@@ -57,7 +57,7 @@ import org.apache.lucene.codecs.lucene70.Lucene70Codec;
 public final class LireCustomCodec extends FilterCodec {
 
     public LireCustomCodec() {
-        super("LireCustomCodec", new Lucene70Codec());
+        super("LireCustomCodec", new Lucene80Codec());
     }
 
     @Override

--- a/src/main/java/net/semanticmetadata/lire/searchers/FastOpponentImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/FastOpponentImageSearcher.java
@@ -46,6 +46,7 @@ import net.semanticmetadata.lire.imageanalysis.features.global.OpponentHistogram
 import net.semanticmetadata.lire.utils.ImageUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 
@@ -106,7 +107,7 @@ public class FastOpponentImageSearcher extends AbstractImageSearcher {
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         Document d;
         double tmpDistance;
         int docs = reader.numDocs();

--- a/src/main/java/net/semanticmetadata/lire/searchers/GenericDocValuesImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/GenericDocValuesImageSearcher.java
@@ -186,7 +186,7 @@ public class GenericDocValuesImageSearcher extends AbstractImageSearcher {
         IndexSearcher is = new IndexSearcher(reader);
         TermQuery tq = new TermQuery(new Term(DocumentBuilder.FIELD_NAME_IDENTIFIER, doc.getValues(DocumentBuilder.FIELD_NAME_IDENTIFIER)[0]));
         TopDocs topDocs = is.search(tq, 1);
-        if (topDocs.totalHits > 0) {
+        if (topDocs.totalHits.value > 0) {
             return search(topDocs.scoreDocs[0].doc);
         } else return null;
     }

--- a/src/main/java/net/semanticmetadata/lire/searchers/GenericDocValuesImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/GenericDocValuesImageSearcher.java
@@ -121,7 +121,7 @@ public class GenericDocValuesImageSearcher extends AbstractImageSearcher {
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         Document d;
         double tmpDistance;
         boolean docValueIsThere = true;

--- a/src/main/java/net/semanticmetadata/lire/searchers/GenericFastImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/GenericFastImageSearcher.java
@@ -53,6 +53,7 @@ import net.semanticmetadata.lire.imageanalysis.features.local.simple.SimpleExtra
 import net.semanticmetadata.lire.indexers.parallel.ExtractorItem;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 
@@ -252,7 +253,7 @@ public class GenericFastImageSearcher extends AbstractImageSearcher {
     protected void init() {
         // put all respective features into an in-memory cache ...
         if (isCaching && reader != null) {
-            Bits liveDocs = MultiFields.getLiveDocs(reader);
+            Bits liveDocs = MultiBits.getLiveDocs(reader);
             int docs = reader.numDocs();
             featureCache = new LinkedHashMap<Integer, byte[]>(docs);
             try {
@@ -287,7 +288,7 @@ public class GenericFastImageSearcher extends AbstractImageSearcher {
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         Document d;
         double tmpDistance;
         int docs = reader.numDocs();
@@ -557,7 +558,7 @@ public class GenericFastImageSearcher extends AbstractImageSearcher {
         HashMap<Double, List<String>> duplicates = new HashMap<Double, List<String>>();
 
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
 
         int docs = reader.numDocs();
         int numDuplicates = 0;

--- a/src/main/java/net/semanticmetadata/lire/searchers/ImageSearcherUsingWSs.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/ImageSearcherUsingWSs.java
@@ -7,6 +7,7 @@ import net.semanticmetadata.lire.imageanalysis.features.LocalFeatureExtractor;
 import net.semanticmetadata.lire.imageanalysis.features.local.simple.SimpleExtractor;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 
@@ -161,7 +162,7 @@ public class ImageSearcherUsingWSs extends GenericFastImageSearcher {
     protected void init() {
         // put all respective features into an in-memory cache ...
         if (reader != null && reader.numDocs() > 0) {
-            Bits liveDocs = MultiFields.getLiveDocs(reader);
+            Bits liveDocs = MultiBits.getLiveDocs(reader);
             int docs = reader.numDocs();
             featureCache = new LinkedHashMap<Integer, byte[]>(docs);
             try {
@@ -210,7 +211,7 @@ public class ImageSearcherUsingWSs extends GenericFastImageSearcher {
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-//        Bits liveDocs = MultiFields.getLiveDocs(reader);
+//        Bits liveDocs = MultiBits.getLiveDocs(reader);
 //        Document d;
 //        float tmpDistance;
 //        int docs = reader.numDocs();

--- a/src/main/java/net/semanticmetadata/lire/searchers/LshImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/LshImageSearcher.java
@@ -176,11 +176,6 @@ public class LshImageSearcher extends AbstractImageSearcher {
             public float idf(long docFreq, long numDocs) {
                 return 1;
             }
-
-            @Override
-            public float sloppyFreq(int distance) {
-                return 1;
-            }
         });
         BooleanQuery.Builder queryBuilder = new BooleanQuery.Builder();
         for (int i = 0; i < hashes.length; i++) {

--- a/src/main/java/net/semanticmetadata/lire/searchers/MetricSpacesImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/MetricSpacesImageSearcher.java
@@ -212,7 +212,7 @@ public class MetricSpacesImageSearcher extends AbstractImageSearcher {
             docValues = MultiDocValues.getBinaryValues(reader, featureFieldName);
             // find the id of the document in the reader, then do search ... TODO: find another way instead of calling the searcher every time.
             TopDocs topDocs = searcher.search(new TermQuery(new Term(DocumentBuilder.FIELD_NAME_IDENTIFIER, doc.get(DocumentBuilder.FIELD_NAME_IDENTIFIER))), 1);
-            if (topDocs.totalHits > 0) {
+            if (topDocs.totalHits.value > 0) {
                 int docID = topDocs.scoreDocs[0].doc;
                 docValues.advanceExact(docID);
                 queryFeature.setByteArrayRepresentation(docValues.binaryValue().bytes, docValues.binaryValue().offset, docValues.binaryValue().length);

--- a/src/main/java/net/semanticmetadata/lire/searchers/VisualWordsImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/VisualWordsImageSearcher.java
@@ -131,16 +131,6 @@ public class VisualWordsImageSearcher extends AbstractImageSearcher {
         }
 
         @Override
-        public float sloppyFreq(int distance) {
-            return super.sloppyFreq(distance);
-        }
-
-        @Override
-        public float scorePayload(int doc, int start, int end, BytesRef payload) {
-            return super.scorePayload(doc, start, end, payload);
-        }
-
-        @Override
         public float idf(long docFreq, long numDocs) {
             return 1f; //super.idf(docFreq, numDocs);
         }

--- a/src/main/java/net/semanticmetadata/lire/searchers/custom/TopDocsImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/custom/TopDocsImageSearcher.java
@@ -121,7 +121,7 @@ public class TopDocsImageSearcher {
         // Needed for check whether the document is deleted.
         Bits liveDocs = MultiBits.getLiveDocs(reader);
 
-        long docs = results.totalHits;
+        long docs = results.totalHits.value;
         for (int i = 0; i < docs; i++) {
             if (reader.hasDeletions() && !liveDocs.get(i)) continue; // if it is deleted, just ignore it.
 

--- a/src/main/java/net/semanticmetadata/lire/searchers/custom/TopDocsImageSearcher.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/custom/TopDocsImageSearcher.java
@@ -46,6 +46,7 @@ import net.semanticmetadata.lire.searchers.SimpleResult;
 import net.semanticmetadata.lire.utils.ImageUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.util.Bits;
@@ -118,7 +119,7 @@ public class TopDocsImageSearcher {
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
 
         long docs = results.totalHits;
         for (int i = 0; i < docs; i++) {

--- a/src/main/java/net/semanticmetadata/lire/searchers/forevaluations/GenericFastImageSearcherForEvaluation.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/forevaluations/GenericFastImageSearcherForEvaluation.java
@@ -56,6 +56,7 @@ import net.semanticmetadata.lire.searchers.ImageDuplicates;
 import net.semanticmetadata.lire.searchers.SimpleImageDuplicates;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 
@@ -254,7 +255,7 @@ public class GenericFastImageSearcherForEvaluation extends AbstractImageSearcher
     protected void init() {
         // put all respective features into an in-memory cache ...
         if (isCaching && reader != null) {
-            Bits liveDocs = MultiFields.getLiveDocs(reader);
+            Bits liveDocs = MultiBits.getLiveDocs(reader);
             int docs = reader.numDocs();
             featureCache = new LinkedHashMap<Integer, SearchItemForEvaluation>(docs);
             try {
@@ -285,7 +286,7 @@ public class GenericFastImageSearcherForEvaluation extends AbstractImageSearcher
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         Document d;
         double tmpDistance;
         int docs = reader.numDocs();
@@ -538,7 +539,7 @@ public class GenericFastImageSearcherForEvaluation extends AbstractImageSearcher
         HashMap<Double, List<String>> duplicates = new HashMap<Double, List<String>>();
 
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
 
         int docs = reader.numDocs();
         int numDuplicates = 0;

--- a/src/main/java/net/semanticmetadata/lire/searchers/forevaluations/ImageSearcherUsingWSsForEvaluation.java
+++ b/src/main/java/net/semanticmetadata/lire/searchers/forevaluations/ImageSearcherUsingWSsForEvaluation.java
@@ -8,6 +8,7 @@ import net.semanticmetadata.lire.imageanalysis.features.LocalFeatureExtractor;
 import net.semanticmetadata.lire.imageanalysis.features.local.simple.SimpleExtractor;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 
@@ -162,7 +163,7 @@ public class ImageSearcherUsingWSsForEvaluation extends GenericFastImageSearcher
     protected void init() {
         // put all respective features into an in-memory cache ...
         if (reader != null && reader.numDocs() > 0) {
-            Bits liveDocs = MultiFields.getLiveDocs(reader);
+            Bits liveDocs = MultiBits.getLiveDocs(reader);
             int docs = reader.numDocs();
             featureCache = new LinkedHashMap<Integer, SearchItemForEvaluation>(docs);
             try {
@@ -207,7 +208,7 @@ public class ImageSearcherUsingWSsForEvaluation extends GenericFastImageSearcher
         // clear result set ...
         docs.clear();
         // Needed for check whether the document is deleted.
-//        Bits liveDocs = MultiFields.getLiveDocs(reader);
+//        Bits liveDocs = MultiBits.getLiveDocs(reader);
 //        Document d;
 //        float tmpDistance;
 //        int docs = reader.numDocs();

--- a/src/test/java/net/semanticmetadata/lire/benchmarking/TestUniversal.java
+++ b/src/test/java/net/semanticmetadata/lire/benchmarking/TestUniversal.java
@@ -68,6 +68,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
@@ -359,7 +360,7 @@ public class TestUniversal extends TestCase {
         double p10 = 0;
         int errorCount=0;
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         PrintWriter fw;
         if (searcher.toString().contains("ImageSearcherUsingWSs")) {
             (new File("eval/" + db + "/" + prefix.replace(' ', '_') + "/" + clusters + "/")).mkdirs();
@@ -491,7 +492,7 @@ public class TestUniversal extends TestCase {
         parallelIndexer.addExtractor(featureClass);
         parallelIndexer.run();
         IndexReader reader = DirectoryReader.open(new RAMDirectory(FSDirectory.open(Paths.get(indexPath)), IOContext.READONCE));
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         double queryCount = 0d;
         ImageSearcher searcher = new GenericFastImageSearcher(100, featureClass);
         long ms = System.currentTimeMillis();

--- a/src/test/java/net/semanticmetadata/lire/benchmarking/TestZuBuD.java
+++ b/src/test/java/net/semanticmetadata/lire/benchmarking/TestZuBuD.java
@@ -60,6 +60,7 @@ import net.semanticmetadata.lire.searchers.ImageSearcherUsingWSs;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
@@ -329,7 +330,7 @@ public class TestZuBuD extends TestCase {
         double p10 = 0;
         int errorCount=0;
         // Needed for check whether the document is deleted.
-        Bits liveDocs = MultiFields.getLiveDocs(readerQueries);
+        Bits liveDocs = MultiBits.getLiveDocs(readerQueries);
         PrintWriter fw;
         if (searcher.toString().contains("ImageSearcherUsingWSs")) {
             (new File("eval/" + db + "/" + prefix.replace(' ', '_') + "/" + clusters + "/")).mkdirs();

--- a/src/test/java/net/semanticmetadata/lire/searchers/TestSearching.java
+++ b/src/test/java/net/semanticmetadata/lire/searchers/TestSearching.java
@@ -49,6 +49,7 @@ import net.semanticmetadata.lire.utils.FileUtils;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.IOContext;
@@ -215,7 +216,7 @@ public class TestSearching extends TestCase {
         GenericFastImageSearcher cvsurfsearcher = new GenericFastImageSearcher(5, localFeatureClass, aggregatorClass.newInstance(), 512, true, readerIndex, indexPath + ".config");
         GenericFastImageSearcher simpleceddcvsurfsearcher = new GenericFastImageSearcher(5, globalFeatureClass, keypointDetector, aggregatorClass.newInstance(), 512, true, readerIndex, indexPath + ".config");
 
-        Bits liveDocs = MultiFields.getLiveDocs(readerQueries);
+        Bits liveDocs = MultiBits.getLiveDocs(readerQueries);
 
         ImageSearchHits ceddhits, cvsurfhits, simpleceddcvsurfhits;
         Document queryDoc;


### PR DESCRIPTION
Tests are failing, any help ?

```
Working Directory: /Users/simoncampano/dev/LIRE
Gradle user home: /Users/simoncampano/.gradle
Gradle Distribution: Gradle wrapper from target build
Gradle Version: 5.0
Java Home: /Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home
JVM Arguments: None
Program Arguments: None
Build Scans Enabled: false
Offline Mode Enabled: false
Gradle Tasks: build


> Task :compileJava
Note: /Users/simoncampano/dev/LIRE/src/main/java/net/semanticmetadata/lire/utils/LuceneUtils.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processResources
> Task :classes
> Task :jar
> Task :assemble

> Task :compileTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /Users/simoncampano/dev/LIRE/src/test/java/net/semanticmetadata/lire/TestProperties.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :processTestResources
> Task :testClasses

> Task :test

net.semanticmetadata.lire.applications.GlobalFeatureIndexSearchTest > testIndexing FAILED
    java.lang.IllegalArgumentException at GlobalFeatureIndexSearchTest.java:45

net.semanticmetadata.lire.applications.GlobalFeatureIndexSearchTest > testIndexingDocValues FAILED
    java.lang.IllegalArgumentException at GlobalFeatureIndexSearchTest.java:52

net.semanticmetadata.lire.applications.GlobalFeatureIndexSearchTest > testSearchCaching FAILED
    org.apache.lucene.index.IndexNotFoundException at GlobalFeatureIndexSearchTest.java:76

net.semanticmetadata.lire.applications.GlobalFeatureIndexSearchTest > testSearchDocValues FAILED
    org.apache.lucene.index.IndexNotFoundException at GlobalFeatureIndexSearchTest.java:56

net.semanticmetadata.lire.applications.GlobalFeatureIndexSearchTest > testSearchPlain FAILED
    org.apache.lucene.index.IndexNotFoundException at GlobalFeatureIndexSearchTest.java:96

20 tests completed, 5 failed

> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///Users/simoncampano/dev/LIRE/build/reports/tests/test/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 23s
6 actionable tasks: 6 executed
```
